### PR TITLE
Remove explicit subnet from external config

### DIFF
--- a/docker-compose.external-couch.yml
+++ b/docker-compose.external-couch.yml
@@ -47,6 +47,3 @@ services:
 
 networks:
   couch-external-net:
-    ipam:
-      config:
-        - subnet: 172.16.0.0/16


### PR DESCRIPTION
by declaring the `networks:` like this:

```
networks:
  couch-external-net:
    ipam:
      config:
        - subnet: 172.16.0.0/16
```

We collide with the default docker subnet value (also `172.16.0.0/16`).  Better to let docker implicitly decide which subnet it wants to use, as it's more important we name the network (`couch-external-net` in this case) than to specify the exact subnet.  

Well, that is, unless I'm missing a good reason to do this - I'm all ears!